### PR TITLE
Fix ref period label

### DIFF
--- a/src/graphql_qb/types.clj
+++ b/src/graphql_qb/types.clj
@@ -179,7 +179,7 @@
       (cond
         (is-ref-period-type? type)
         {:uri   (->PathProjection [[dim-key uri]] false identity)
-         :label (->PathProjection [[dim-key :label]] true identity)
+         :label (->PathProjection [[dim-key uri][:label rdfs:label]] true identity)
          :start (->PathProjection [[dim-key uri] [:begin time:hasBeginning] [:time time:inXSDDateTime]] true grafter-date->datetime)
          :end   (->PathProjection [[dim-key uri] [:end time:hasEnd] [:time time:inXSDDateTime]] true grafter-date->datetime)}
         (is-ref-area-type? type)


### PR DESCRIPTION
Fix #94 

The result is now like this:

```
...
"reference_period": {
                "end": "2017-01-01T00:00:00Z",
                "label": "2016",
                "start": "2016-01-01T00:00:00Z",
                "uri": "http://reference.data.gov.uk/id/year/2016"
 }
...
```