### PR TITLE
Fix #87 - Timeout Exception

### DIFF
--- a/src/graphql_qb/queries.clj
+++ b/src/graphql_qb/queries.clj
@@ -3,13 +3,17 @@
             [graphql-qb.types :as types]
             [grafter.rdf.sparql :as sp]
             [graphql-qb.vocabulary :refer :all]
-            [graphql-qb.query-model :as qm]))
+            [graphql-qb.query-model :as qm])
+  (:import  [java.net URI]))
 
 (defn get-observation-filter-model [dim-filter]
-  (reduce (fn [m [dim value]]
-            (types/apply-filter dim m value))
-          qm/empty-model
-          dim-filter))
+   (let [m (-> qm/empty-model
+                    (qm/add-binding [[:mp (URI. "http://purl.org/linked-data/cube#measureType")]] ::qm/var)
+                    (qm/add-binding [[:mv (qm/->QueryVar "mp")]] ::qm/var))]
+       (reduce (fn [m [dim value]]
+                       (types/apply-filter dim m value))
+                     m
+                     dim-filter)))
 
 (defn apply-model-projections [filter-model dataset observation-selections]
   (reduce (fn [m dm]

--- a/src/graphql_qb/schema.clj
+++ b/src/graphql_qb/schema.clj
@@ -57,7 +57,8 @@
 (defn wrap-observations-mapping [inner-resolver dataset dataset-enum-mappings]
   (fn [context args observations-field]
     (let [result (inner-resolver context args observations-field)
-          projection (merge {:uri :obs} (types/dataset-result-projection dataset))
+          updated-result (first (::resolvers/observation-results result))
+          projection (merge {:uri :obs} (types/dataset-result-projection dataset updated-result))
           result-mapping (mapping/get-dataset-observations-result-mapping dataset dataset-enum-mappings)
           mapped-result (mapv (fn [obs-bindings]
                                 (let [sparql-result (types/project-result projection obs-bindings)]


### PR DESCRIPTION
The Timeout exception was due to the `OPTIONAL` clauses at SPARQL queries.

The changes to the SPARQL queries are:
- Remove the OPTIONAL for the refArea and refPeriod labels
- Removed the OPTIONAL for the measures 

The queries for the measures are like this:

```
?obs <http://purl.org/linked-data/cube#measureType> ?mp .
?obs ?mp ?mv
```