### PR TITLE
Change dataset metadata types to lists.

### DIFF
--- a/resources/base-schema.edn
+++ b/resources/base-schema.edn
@@ -11,11 +11,11 @@
    :fields
    {:uri         {:type :uri :description "Dataset URI"}
     :title       {:type String :description "Dataset title"}
-    :description {:type String :description "Dataset description"}
-    :licence     {:type :uri :description "URI of the licence the dataset is published under"}
-    :issued      {:type :DateTime :description "When the dataset was issued"}
+    :description {:type (list String) :description "Dataset descriptions"}
+    :licence     {:type (list :uri) :description "URIs of the licences the dataset is published under"}
+    :issued      {:type (list :DateTime) :description "When the dataset was issued"}
     :modified    {:type :DateTime :description "When the dataset was last modified"}
-    :publisher   {:type :uri :description "URI of the publisher of the dataset"}
+    :publisher   {:type (list :uri) :description "URIs of the publishers of the dataset"}
     :schema      {:type String :description "Name of the GraphQL query root field corresponding to this dataset"}
     :dimensions  {:type        (list :dim)
                   :resolve     :resolve-dataset-dimensions
@@ -68,10 +68,10 @@
    :fields
    {:uri         {:type :uri :description "Dataset URI"}
     :title       {:type String :description "Dataset title"}
-    :description {:type String :description "Dataset description"}
+    :description {:type (list String) :description "Dataset description"}
     :schema      {:type String :description "Name of the GraphQL query root field corresponding to this dataset"}
     :dimensions  {:type (list :dim) :description "Dimensions within the dataset"}
-    :measures {:type (list :measure) :description "Measure types within the dataset"}}}
+    :measures    {:type (list :measure) :description "Measure types within the dataset"}}}
   :resource
   {:description "Resource with a URI and optional label"
    :fields

--- a/src/graphql_qb/core.clj
+++ b/src/graphql_qb/core.clj
@@ -51,18 +51,12 @@
 (defn construct-datasets [datasets dataset-enum-values dataset-measures known-dimensions known-dimension-members]
   (let [dataset-enum-values (group-by :ds dataset-enum-values)
         datasets (map (fn [{uri :ds :as dataset}]
-                        (let [{:keys [issued modified publisher licence]} dataset
-                              enum-dim-values (get dataset-enum-values uri)
+                        (let [enum-dim-values (get dataset-enum-values uri)
                               measures-mapping (get-dataset-measures-mapping dataset-measures)
                               enum-dims (get-dataset-enum-dimensions enum-dim-values)
                               dimensions (get-dataset-dimensions uri known-dimensions known-dimension-members enum-dims)
-                              measures (or (get measures-mapping uri) [])
-                              d (types/->Dataset uri (:name dataset) dimensions measures)]
-                          (assoc d
-                            :issued (some-> issued (scalars/grafter-date->datetime))
-                            :modified (some-> modified (scalars/grafter-date->datetime))
-                            :publisher publisher
-                            :licence licence)))
+                              measures (or (get measures-mapping uri) [])]
+                          (types/->Dataset uri (:name dataset) dimensions measures)))
                       datasets)]
     (filter can-generate-schema? datasets)))
 
@@ -102,7 +96,7 @@
    4. Get all dimension values for all enum dimensions
    5. Get all dataset measures
    6. Construct datasets"
-  (let [datasets (queries/get-datasets repo nil nil nil configuration nil)
+  (let [datasets (queries/get-datasets repo nil nil nil configuration)
         area-dim (config/geo-dimension configuration)
         time-dim (config/time-dimension configuration)
         known-dimension-types [[area-dim (types/->RefAreaType)]

--- a/src/graphql_qb/queries.clj
+++ b/src/graphql_qb/queries.clj
@@ -140,9 +140,8 @@
     (process-dataset-metadata-bindings bindings)))
 
 (defn get-datasets [repo dimensions measures uri configuration]
-  (let [q (get-datasets-query dimensions measures uri configuration)
-        results (util/eager-query repo q)]
-    results))
+  (let [q (get-datasets-query dimensions measures uri configuration)]
+    (util/eager-query repo q)))
 
 (defn get-dimension-codelist-values-query [ds-uri configuration lang]
   (let [codelist-label (config/codelist-label configuration)]

--- a/src/graphql_qb/resolvers.clj
+++ b/src/graphql_qb/resolvers.clj
@@ -133,8 +133,9 @@
         results (queries/get-datasets repo dimensions measures uri config)]
     (map (fn [ds]
            (let [{:keys [uri] :as dataset} (util/rename-key ds :ds :uri)
-                 metadata (queries/get-dataset-metadata repo uri config lang)]
-             (merge dataset metadata)))
+                 metadata (queries/get-dataset-metadata repo uri config lang)
+                 with-metadata (merge dataset metadata)]
+             (assoc with-metadata :schema (name (types/dataset-name->schema-name (:name dataset))))))
          results)))
 
 (defn exec-observation-aggregation [repo dataset measure filter-model aggregation-fn]
@@ -174,8 +175,9 @@
     (let [repo (context/get-repository context)
           config (context/get-configuration context)
           lang (get-lang field)
-          metadata (queries/get-dataset-metadata repo uri config lang)]
-      {::dataset (merge dataset metadata)})))
+          metadata (queries/get-dataset-metadata repo uri config lang)
+          with-metadata (merge dataset metadata)]
+      {::dataset (assoc with-metadata :schema (name (types/dataset-name->schema-name (:name dataset))))})))
 
 (defn dataset-dimensions-resolver [all-enum-mappings]
   (fn [context _args {:keys [uri] :as ds-field}]

--- a/src/graphql_qb/schema.clj
+++ b/src/graphql_qb/schema.clj
@@ -145,11 +145,11 @@
                {:implements  [:dataset_meta]
                 :fields      {:uri          {:type :uri :description "Dataset URI"}
                               :title        {:type 'String :description "Dataset title"}
-                              :description  {:type 'String :description "Dataset description"}
-                              :licence      {:type :uri :description "URI of the licence the dataset is published under"}
-                              :issued       {:type :DateTime :description "When the dataset was issued"}
+                              :description  {:type ['String] :description "Dataset descriptions"}
+                              :licence      {:type [:uri] :description "URIs of the licences the dataset is published under"}
+                              :issued       {:type [:DateTime] :description "When the dataset was issued"}
                               :modified     {:type :DateTime :description "When the dataset was last modified"}
-                              :publisher    {:type :uri :description "URI of the publisher of the dataset"}
+                              :publisher    {:type [:uri] :description "URIs of the publishers of the dataset"}
                               :schema       {:type 'String :description "Name of the GraphQL query root field corresponding to this dataset"}
                               :dimensions   {:type        [:dim]
                                              :resolve     (resolvers/create-dataset-dimensions-resolver dataset dataset-enum-mappings)

--- a/src/graphql_qb/types.clj
+++ b/src/graphql_qb/types.clj
@@ -23,7 +23,7 @@
        (string/join "_")
        (keyword)))
 
-(defn dataset-label->schema-name [label]
+(defn dataset-name->schema-name [label]
   (segments->schema-key (cons "dataset" (get-identifier-segments label))))
 
 (defn label->field-name [label]
@@ -216,7 +216,7 @@
 (defrecord Dataset [uri name dimensions measures])
 
 (defn dataset-schema [ds]
-  (keyword (dataset-label->schema-name (:name ds))))
+  (keyword (dataset-name->schema-name (:name ds))))
 
 (defn dataset-aggregate-measures [{:keys [measures] :as ds}]
   (filter :is-numeric? measures))


### PR DESCRIPTION
Issue #96 - Change the dataset description, issued, licence and
publisher fields to return lists. Separate the retrieval of the metadata
from the rest of the dataset.