### PR TITLE
Allow the predicate relating components to codelists to be configured.

### DIFF
--- a/src/graphql_qb/config.clj
+++ b/src/graphql_qb/config.clj
@@ -29,6 +29,11 @@
     "component" "?comp"
     "?dim"))
 
+(defn codelist-predicate [{predicate :codelist-predicate :as config}]
+  (if (nil? predicate)
+    qb:codeList
+    (URI. predicate)))
+
 (defn codelist-label [{config-cl-label :codelist-label-uri :as config}]
   ;;Return the default skos:prefLabel if :codelist-label-uri is not defined at configuration
   (if (nil? config-cl-label)

--- a/src/graphql_qb/dataset_model.clj
+++ b/src/graphql_qb/dataset_model.clj
@@ -94,7 +94,7 @@
     "  ?dsd qb:component ?comp ."
     "  OPTIONAL { ?comp qb:order ?order }"
     "  OPTIONAL { ?comp qb:dimension ?dim }"
-    "  OPTIONAL { " (config/codelist-source configuration) " qb:codeList ?codelist }"
+    "  OPTIONAL { " (config/codelist-source configuration) " <" (config/codelist-predicate configuration) "> ?codelist }"
     "  OPTIONAL { ?comp qb:measure ?measure }"
     "}"))
 
@@ -117,7 +117,7 @@
       "  ?dsd qb:component ?comp ."
       "  ?comp qb:dimension ?dim ."
       (string/join "\n" dimension-filters)
-      (config/codelist-source configuration) " qb:codeList ?codelist ."
+      (config/codelist-source configuration) " <" (config/codelist-predicate configuration) "> ?codelist ."
       "  ?codelist skos:member ?member ."
       "}")))
 

--- a/src/graphql_qb/queries.clj
+++ b/src/graphql_qb/queries.clj
@@ -148,7 +148,8 @@
     (process-dataset-metadata-bindings bindings)))
 
 (defn get-dimension-codelist-values-query [ds-uri configuration lang]
-  (let [codelist-label (config/codelist-label configuration)]
+  (let [codelist-label (config/codelist-label configuration)
+        codelist-predicate (config/codelist-predicate configuration)]
     (str
       "PREFIX qb: <http://purl.org/linked-data/cube#>"
       "PREFIX skos: <http://www.w3.org/2004/02/skos/core#>"
@@ -159,7 +160,7 @@
       "?struct a qb:DataStructureDefinition ."
       "?struct qb:component ?comp ."
       "?comp qb:dimension ?dim ."
-      (config/codelist-source configuration) " qb:codeList ?list  ."
+      (config/codelist-source configuration) " <" codelist-predicate "> ?list ."
       "?list skos:member ?member ."
       "OPTIONAL {"
       "  ?member <" (str codelist-label) "> ?label ."
@@ -179,6 +180,7 @@
   code used to generate the enum name."
   [configuration]
   (let [codelist-label (config/codelist-label configuration)
+        codelist-predicate (config/codelist-predicate configuration)
         ignored-dimensions (config/ignored-codelist-dimensions configuration)
         dimension-filters (map (fn [dim-uri] (format "FILTER(?dim != <%s>)" dim-uri)) ignored-dimensions)]
     (str
@@ -193,7 +195,7 @@
       "  ?comp qb:dimension ?dim ."
       (string/join "\n" dimension-filters)
       "  OPTIONAL { ?dim rdfs:comment ?doc }"
-      (config/codelist-source configuration) " qb:codeList ?codelist ."
+      (config/codelist-source configuration) " <" codelist-predicate "> ?codelist ."
       "  ?codelist skos:member ?member ."
       "  ?member <" (str codelist-label) "> ?vallabel ."
       "}")))

--- a/src/graphql_qb/vocabulary.clj
+++ b/src/graphql_qb/vocabulary.clj
@@ -8,3 +8,4 @@
 (def time:inXSDDateTime (URI. "http://www.w3.org/2006/time#inXSDDateTime"))
 (def rdfs:label (URI. "http://www.w3.org/2000/01/rdf-schema#label"))
 (def skos:prefLabel (URI. "http://www.w3.org/2004/02/skos/core#prefLabel"))
+(def qb:codeList (URI. "http://purl.org/linked-data/cube#codeList"))


### PR DESCRIPTION
Issue #117 - Cubes may use a predicate other than qb:codeList to
relate a dataset component or dimension to its codelist. Add a
:codelist-predicate configuration option which allows the predicate
to be specified. If not configured, qb:codeList will be used.