### PR TITLE
Fix issue 131

### DIFF
--- a/src/graphql_qb/queries.clj
+++ b/src/graphql_qb/queries.clj
@@ -104,7 +104,7 @@
       "PREFIX qb: <http://purl.org/linked-data/cube#>"
       "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>"
       "PREFIX dcterms: <http://purl.org/dc/terms/>"
-      "SELECT * WHERE {"
+      "SELECT distinct * WHERE {"
       "  <" dataset-uri "> a qb:DataSet ."
       "{"
       "    <" dataset-uri "> <" label-predicate "> ?title ."


### PR DESCRIPTION
The multiple values where due to multiple  `XXX a qb:DataSet` triples at the Scotish portal. Using a DISITINCT at the query returns unique results.