### PR TITLE
Use SELECT instead of ASK query when checking numeric measures.

### DIFF
--- a/resources/is-measure-numeric.sparql
+++ b/resources/is-measure-numeric.sparql
@@ -1,7 +1,7 @@
 PREFIX qb: <http://purl.org/linked-data/cube#>
 
-ASK WHERE {
+SELECT ?numeric WHERE {
   ?obs a qb:Observation .
   ?obs ?measure ?val .
-  FILTER(isNumeric(?val))
-}
+  BIND(isNumeric(?val) AS ?numeric)
+} LIMIT 1

--- a/src/graphql_qb/dataset_model.clj
+++ b/src/graphql_qb/dataset_model.clj
@@ -40,8 +40,14 @@
 (defn measure-bindings->measures [measure-bindings]
   (map #(util/rename-key % :measure :uri) measure-bindings))
 
-(defn- is-measure-numeric? [repo measure-uri]
-  (sp/query "is-measure-numeric.sparql" {:measure measure-uri} repo))
+(defn- is-measure-numeric?
+  "Queries for an observation for the specified measure. Returns true if the value of the observation is numeric, false
+   if there are no matching observations or the value is non-numeric."
+  [repo measure-uri]
+  (let [results (sp/query "is-measure-numeric.sparql" {:measure measure-uri} repo)]
+    (if-let [solution (first results)]
+      (:numeric solution)
+      false)))
 
 (defn find-numeric-measures [repo all-measures]
   (into #{} (keep (fn [{:keys [uri] :as measure}]

--- a/src/graphql_qb/dataset_model.clj
+++ b/src/graphql_qb/dataset_model.clj
@@ -46,7 +46,7 @@
   [repo measure-uri]
   (let [results (sp/query "is-measure-numeric.sparql" {:measure measure-uri} repo)]
     (if-let [solution (first results)]
-      (:numeric solution)
+      (util/xmls-boolean->boolean (:numeric solution))
       false)))
 
 (defn find-numeric-measures [repo all-measures]

--- a/src/graphql_qb/util.clj
+++ b/src/graphql_qb/util.clj
@@ -171,3 +171,12 @@
               (update acc k (fnil conj []) v))
             {}
             non-nil-pairs)))
+
+(defn xmls-boolean->boolean
+  "XML Schema allows boolean values to be represented as the literals true, false 0 or 1.
+   This function converts the clojure representation of those values into the corresponding
+   boolean value."
+  [xb]
+  (if (number? xb)
+    (= 1 xb)
+    (boolean xb)))

--- a/test/graphql_qb/util_test.clj
+++ b/test/graphql_qb/util_test.clj
@@ -78,3 +78,13 @@
             :c [4 8 10]
             :d [6 9]}
            (to-multimap maps)))))
+
+(deftest xmls-boolean->boolean-test
+  (are [b expected] (= expected (xmls-boolean->boolean b))
+    false false
+    true true
+    0 false
+    0N false
+    1 true
+    1N true
+    nil false))


### PR DESCRIPTION
Issue #134 - Use a SELECT query instead of an ASK query when checking
if a measure is numeric. The default configuration of the SPARQL
client does not work for ASK queries against some databases
(e.g. Virtuoso).